### PR TITLE
fix: 14장 '베스트 모델 만들기' 예제 코드(14-3) 수정

### DIFF
--- a/deeplearning/run_project/10_Wine_Overfit_Graph.ipynb
+++ b/deeplearning/run_project/10_Wine_Overfit_Graph.ipynb
@@ -7459,7 +7459,7 @@
     "y_vloss=history.history['val_loss']\n",
     "\n",
     "# y_acc 에 학습 셋으로 측정한 정확도의 값을 저장\n",
-    "y_acc=history.history['acc']\n",
+    "y_acc=history.history['accuracy']\n",
     "\n",
     "# x값을 지정하고 정확도를 파란색으로, 오차를 빨간색으로 표시\n",
     "x_len = numpy.arange(len(y_acc))\n",


### PR DESCRIPTION
케라스의 "fit()" 함수가 반환하는 "history" 정보에서 정확도 값을 가져오기 위한 key값을 "acc"에서 "accuracy"로 수정

resolved: #5 